### PR TITLE
Prevent ellipsis addition to text the same height as max line height

### DIFF
--- a/clamp.js
+++ b/clamp.js
@@ -256,7 +256,7 @@
       }
     } else {
       var height = getMaxHeight(clampValue);
-      if (height <= element.clientHeight) {
+      if (height < element.clientHeight) {
         clampedText = truncate(getLastChild(element), height);
       }
     }


### PR DESCRIPTION
Scenario:
Use the JavaScript functionality of clamp.js on a div that has the same number of lines of text as are requested in the clamp options. 

In this case, clamp code will measure and see the height of the element to be equal to the height of the number of lines and will call the truncate functionality. This ends up adding an ellipsis to the end of the text, even though the full text fits in the element without truncation.

What I think should happen is that clamp.js should not run truncation unless the element is smaller than the height needed for the lines of text. In that case the truncate functionality is never called in the scenario when the element is the same size as the value to check.

Here is a fiddle that tries to give the general idea (although the version of clamp.js used is outdated it still exhibits the same behavior). https://jsfiddle.net/eshtadc/oap03cc5/